### PR TITLE
Add link to blog post to presentation folder

### DIFF
--- a/visual-perception-of-code/README.md
+++ b/visual-perception-of-code/README.md
@@ -1,0 +1,3 @@
+# The Visual Perception of Code
+
+https://www.stitcher.io/blog/visual-perception-of-code


### PR DESCRIPTION
I thought I'd add a link to the presentation's blog post in a README file in the presentation's folder, in case someone stumbles upon it here and wants a quick way to actually see the presentation and/or read the associated blog post 🙂 